### PR TITLE
Optimise .card border-radius CSS

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -78,17 +78,8 @@ body #app .card-content {
 }
 
  /*Adds more border radius to the cards */
-body .layout-vertical .column div:first-of-type .card {
-  border-radius: 1rem;
-}
-body .layout-vertical .card {
-  border-radius: 1rem;
-}
 .card {
-    border-radius: 1rem;
-}
-body .layout-vertical .column div:last-of-type .card { 
-    border-radius: 1rem; 
+  border-radius: 1rem !important;
 }
 
 /* Changes Header Opacity */


### PR DESCRIPTION
Add !important to .card border-radius rule and remove no longer required rules.